### PR TITLE
Vandens pavadinimai grąžinami kaip taškai, kad nesikartotų susikirtimuose

### DIFF
--- a/queries/places/z14.pgsql
+++ b/queries/places/z14.pgsql
@@ -16,3 +16,14 @@ FROM
 WHERE
   name IS NOT NULL AND
   (place IN ('city', 'town', 'village', 'hamlet', 'locality'))
+union all
+SELECT
+  ST_PointOnSurface(way) AS __geometry__,
+  name,
+  'water' AS kind,
+  null AS population
+FROM
+  planet_osm_polygon
+WHERE
+  name IS NOT NULL AND
+  (natural = 'water' or landuse = 'reservoir')

--- a/tiles.cfg
+++ b/tiles.cfg
@@ -55,8 +55,7 @@
             "15": "queries/water/z11.pgsql",
             "16": "queries/water/z16.pgsql"
           },
-          "srid": 3857,
-          "clip": false
+          "srid": 3857
         }
       }
     },


### PR DESCRIPTION
Grąžinant pilnas vandens objektų (ežerų, tvenkinių) geometrijas neišsprendžiama chaotiškų pavadinimų etikečių problema. Todėl bandome vandens objektų grąžinti kaip taškus, nepriklausomai nuo pačių vandens objektų geometrijos.